### PR TITLE
fix: fix docker info bug on windows

### DIFF
--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 
 export function getDockerInfo(): any {
-  const execRes = execSync('docker info --format \'{{json .}}\'');
+  const execRes = execSync('docker info --format \"{{json .}}\"');
   const dockerInfo = JSON.parse(execRes.toString());
   return dockerInfo;
 }


### PR DESCRIPTION
docker info --format '{{json .}}' will throw error on windows

![image](https://user-images.githubusercontent.com/52195264/137849187-dadf8d68-d557-4f3a-a6ca-29f4ac2544c4.png)
